### PR TITLE
Adding an optional flag to publish the GBP Payload as JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# Eclipse
+.classpath
+.factorypath
+.project
+.settings/
+
 # Compiled class file
 *.class
 

--- a/README.md
+++ b/README.md
@@ -72,12 +72,14 @@ $ java -jar grpc2kafka-1.0.0-SNAPSHOT-onejar.jar
 For more details:
 
 ```SHELL
-$ java -jar grpc2kafka-1.0.0-SNAPSHOT-onejar.jar -h
+$ java -jar grpc2kafka-1.0.0-SNAPSHOT-jar-with-dependencies.jar --help
 usage: grpc2kafka
  -b,--bootstrap-servers <arg>   Kafka bootstrap server list.
                                 Default: 127.0.0.1:9092
  -d,--debug                     Show message on logs.
  -h,--help                      Show this help.
+ -j,--json                      Convert GPB payload to JSON prior send it
+                                to Kafka.
  -p,--port <arg>                gRPC server listener port.
                                 Default: 50051
  -t,--topic <arg>               Kafka destination topic name.

--- a/pom.xml
+++ b/pom.xml
@@ -18,9 +18,9 @@
         </developer>
     </developers>
     <properties>
-        <protocVersion>3.6.1</protocVersion>
-        <grpcVersion>1.17.1</grpcVersion>
-        <kafkaVersion>2.1.0</kafkaVersion>
+        <protobufVersion>3.6.1</protobufVersion>
+        <grpcVersion>1.19.0</grpcVersion>
+        <kafkaVersion>2.1.1</kafkaVersion>
     </properties>
     <build>
         <extensions>
@@ -32,20 +32,11 @@
         </extensions>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <version>0.6.1</version>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:${protocVersion}:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${protobufVersion}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
                     <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpcVersion}:exe:${os.detected.classifier}</pluginArtifact>
                 </configuration>
@@ -57,6 +48,15 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.7.0</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -117,11 +117,22 @@
             <artifactId>log4j-slf4j-impl</artifactId>
             <version>2.11.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
+            <version>${protobufVersion}</version>
+        </dependency>
         <!-- Test -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20180813</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/opennms/features/telemetry/nxos/grpc/server/Grpc2KafkaTest.java
+++ b/src/test/java/org/opennms/features/telemetry/nxos/grpc/server/Grpc2KafkaTest.java
@@ -16,6 +16,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.json.JSONObject;
 import telemetry.TelemetryBis.Telemetry;
 import telemetry.TelemetryBis.TelemetryField;
 
@@ -45,12 +46,56 @@ public class Grpc2KafkaTest {
     @Test
     public void testServer() throws Exception {
         MockProducer<String, byte[]> mockProducer = new MockProducer<>(true, new StringSerializer(), new ByteArraySerializer());
-        grpcServerRule.getServiceRegistry().addService(new NxosMdtDialoutService(mockProducer, "test-topic", true));
+        grpcServerRule.getServiceRegistry().addService(new NxosMdtDialoutService(mockProducer, "test-topic", true, false));
         gRPCMdtDialoutGrpc.gRPCMdtDialoutStub stub = gRPCMdtDialoutGrpc.newStub(grpcServerRule.getChannel());
 
-        CountDownLatch latch = new CountDownLatch(1);
+        final CountDownLatch latch = new CountDownLatch(1);
+        StreamObserver<MdtDialoutArgs> requestObserver = buildRequestObserver(stub, latch);
+        requestObserver.onNext(buildTestDialoutArgs());
+        requestObserver.onCompleted();
+        latch.await(5, TimeUnit.SECONDS);
 
-        StreamObserver<MdtDialoutArgs> requestObserver = stub.mdtDialout(new StreamObserver<MdtDialoutArgs>() {
+        Assert.assertEquals(1, mockProducer.history().size());
+        ProducerRecord<String, byte[]> record = mockProducer.history().get(0);
+        Telemetry kafkaPayload = Telemetry.parseFrom(record.value());
+        Assert.assertEquals("agalue", kafkaPayload.getDataGpbkv(0).getStringValue());
+    }
+
+    /**
+     * Test the gRPC server with Kafka using JSON payload.
+     *
+     * @throws Exception the exception
+     */
+    @Test
+    public void testServerWithJson() throws Exception {
+        MockProducer<String, byte[]> mockProducer = new MockProducer<>(true, new StringSerializer(), new ByteArraySerializer());
+        grpcServerRule.getServiceRegistry().addService(new NxosMdtDialoutService(mockProducer, "test-topic", true, true));
+        gRPCMdtDialoutGrpc.gRPCMdtDialoutStub stub = gRPCMdtDialoutGrpc.newStub(grpcServerRule.getChannel());
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        StreamObserver<MdtDialoutArgs> requestObserver = buildRequestObserver(stub, latch);
+        requestObserver.onNext(buildTestDialoutArgs());
+        requestObserver.onCompleted();
+        latch.await(5, TimeUnit.SECONDS);
+
+        Assert.assertEquals(1, mockProducer.history().size());
+        ProducerRecord<String, byte[]> record = mockProducer.history().get(0);
+        String jsonStr = new String(record.value());
+        LOG.info("Converted JSON: {}", jsonStr);
+        JSONObject json = new JSONObject(jsonStr);
+        Assert.assertEquals("nxos", json.get("nodeIdStr"));
+        Assert.assertEquals("agalue", json.getJSONArray("dataGpbkv").getJSONObject(0).getString("stringValue"));
+    }
+
+    /**
+     * Builds the request observer.
+     *
+     * @param stub the gRPC Stub
+     * @param latch the count down latch object
+     * @return the stream observer object
+     */
+    private StreamObserver<MdtDialoutArgs> buildRequestObserver(final gRPCMdtDialoutGrpc.gRPCMdtDialoutStub stub, final CountDownLatch latch) {
+        return stub.mdtDialout(new StreamObserver<MdtDialoutArgs>() {
             @Override
             public void onNext(MdtDialoutArgs value) {
                 LOG.info("Client has sent some data...");
@@ -69,6 +114,14 @@ public class Grpc2KafkaTest {
             }
         });
 
+    }
+    
+    /**
+     * Builds a test MdtDialoutArgs object.
+     *
+     * @return the new MdtDialoutArgs object
+     */
+    private MdtDialoutArgs buildTestDialoutArgs() {
         TelemetryField field = TelemetryField.newBuilder().setName("owner").setStringValue("agalue").build();
         Telemetry telemetry = Telemetry.newBuilder()
                 .setNodeIdStr("nxos")
@@ -77,19 +130,9 @@ public class Grpc2KafkaTest {
                 .addDataGpbkv(field)
                 .build();
 
-        MdtDialoutArgs requestArgs = MdtDialoutArgs.newBuilder()
+        return MdtDialoutArgs.newBuilder()
                 .setReqId(1)
                 .setData(ByteString.copyFrom(telemetry.toByteArray()))
                 .build();
-        requestObserver.onNext(requestArgs);
-        requestObserver.onCompleted();
-
-        latch.await(5, TimeUnit.SECONDS);
-
-        Assert.assertEquals(1, mockProducer.history().size());
-        ProducerRecord<String, byte[]> record = mockProducer.history().get(0);
-        Telemetry kafkaPayload = Telemetry.parseFrom(record.value());
-        Assert.assertEquals("agalue", kafkaPayload.getDataGpbkv(0).getStringValue());
     }
-
 }


### PR DESCRIPTION
Even if it is natural to work with GPB when implementing a gRPC server, the further integrations from Kafka will have to convert the data in order to parse it and process it.

To minimize the dependencies and effort, there is an optional flag that can be passed to the `jar-with-dependencies`, in order to use the Protobuf Utility classes to convert the object to JSON, prior sending it to Kafka.